### PR TITLE
fix: 디자인 작업을 위한 기본 패딩 제거 및 관련 페이지 수정

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -22,7 +22,9 @@ main {
   width: 100%;
   height: calc(100% - 72px);
   max-height: fit-content;
-  padding: 0 15rem;
+
+  display: flex;
+  justify-content: center;
 }
 
 a {

--- a/src/app/pages/landing-page.tsx
+++ b/src/app/pages/landing-page.tsx
@@ -72,7 +72,6 @@ const styles = {
   `,
   section2: styled.div`
     position: relative;
-    left: -15rem;
     width: 100dvw;
     height: 31.25rem;
     flex-shrink: 0;
@@ -111,7 +110,6 @@ const styles = {
   section4: styled.div`
     display: flex;
     position: relative;
-    left: -15rem;
     width: 100dvw;
     height: 17.9375rem;
     padding: 10.0625rem 38.71875rem 5.0625rem 39.90625rem;

--- a/src/app/pages/main-page.tsx
+++ b/src/app/pages/main-page.tsx
@@ -64,7 +64,7 @@ export function MainPage() {
 
       setAuthUserData(userData);
       if (userData.initialized) {
-        router.replace('/profile');
+        // router.replace('/profile');
       }
     }
   }, [data, router, setAuthUserData]);

--- a/src/app/pages/shared-post-page.tsx
+++ b/src/app/pages/shared-post-page.tsx
@@ -20,7 +20,6 @@ const styles = {
     background: var(--background, #f7f6f9);
 
     position: relative;
-    left: -15rem;
     width: 100dvw;
     min-height: 100%;
     height: fit-content;


### PR DESCRIPTION
## Overview

기본적으로 적용되던 `<main>` 태그의 기본 패딩을 제거하였습니다. 디자인 시안에서 매번 다른 패딩 값을 보이기 때문에 이후 디자인 작업에서 패딩 값을 직접 설정하는 방식으로 변경합니다.

또한, 무조건적으로 가운데 정렬이 되게끔 `<main>` 태그의 디스플레이 속성 값을 수정했습니다.

## Issues

- #43 
